### PR TITLE
Prepare for Rollup 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ module.exports = function(opts = {}) {
           continue;
         }
 
-        const resolvedWorkerFile = await this.resolveId(workerFile, id);
+        const resolvedWorkerFile = (await this.resolve(workerFile, id)).id;
         workerFiles.push(resolvedWorkerFile);
         const chunkRefId = this.emitFile({
           id: resolvedWorkerFile,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "karma-safaritechpreview-launcher": "2.0.2",
     "mocha": "6.1.4",
     "prettier": "1.18.2",
-    "rollup": "^1.32.0"
+    "rollup": "2.0.0-0"
   },
   "repository": {
     "type": "git",

--- a/run_tests.js
+++ b/run_tests.js
@@ -29,40 +29,42 @@ async function fileExists(file) {
 }
 
 async function init() {
-  [
-    "./tests/fixtures/simple-bundle/entry.js",
-    "./tests/fixtures/import-meta/entry.js",
-    "./tests/fixtures/dynamic-import/entry.js",
-    "./tests/fixtures/public-path/entry.js",
-    "./tests/fixtures/worker/entry.js",
-    "./tests/fixtures/more-workers/entry.js",
-    "./tests/fixtures/amd-function-name/entry.js",
-    "./tests/fixtures/single-default/entry.js",
-    "./tests/fixtures/import-worker-url/entry.js",
-    "./tests/fixtures/import-worker-url-custom-scheme/entry.js",
-    "./tests/fixtures/assets-in-worker/entry.js"
-  ].forEach(async input => {
-    const pathName = path.dirname(input);
-    let rollupConfig = {
-      input
-    };
-    const rollupConfigPath = "./" + path.join(pathName, "rollup.config.js");
-    const configPath = "./" + path.join(pathName, "config.json");
-    if (await fileExists(rollupConfigPath)) {
-      require(rollupConfigPath)(rollupConfig, omt);
-    } else if (await fileExists(configPath)) {
-      rollupConfig.plugins = [omt(require(configPath))];
-    } else {
-      rollupConfig.plugins = [omt()];
-    }
-    const bundle = await rollup.rollup(rollupConfig);
-    const outputOptions = {
-      dir: path.join(pathName, "build"),
-      format: "amd"
-    };
-    await bundle.generate(outputOptions);
-    await bundle.write(outputOptions);
-  });
+  await Promise.all(
+    [
+      "./tests/fixtures/simple-bundle/entry.js",
+      "./tests/fixtures/import-meta/entry.js",
+      "./tests/fixtures/dynamic-import/entry.js",
+      "./tests/fixtures/public-path/entry.js",
+      "./tests/fixtures/worker/entry.js",
+      "./tests/fixtures/more-workers/entry.js",
+      "./tests/fixtures/amd-function-name/entry.js",
+      "./tests/fixtures/single-default/entry.js",
+      "./tests/fixtures/import-worker-url/entry.js",
+      "./tests/fixtures/import-worker-url-custom-scheme/entry.js",
+      "./tests/fixtures/assets-in-worker/entry.js"
+    ].map(async input => {
+      const pathName = path.dirname(input);
+      let rollupConfig = {
+        input
+      };
+      const rollupConfigPath = "./" + path.join(pathName, "rollup.config.js");
+      const configPath = "./" + path.join(pathName, "config.json");
+      if (await fileExists(rollupConfigPath)) {
+        require(rollupConfigPath)(rollupConfig, omt);
+      } else if (await fileExists(configPath)) {
+        rollupConfig.plugins = [omt(require(configPath))];
+      } else {
+        rollupConfig.plugins = [omt()];
+      }
+      const bundle = await rollup.rollup(rollupConfig);
+      const outputOptions = {
+        dir: path.join(pathName, "build"),
+        format: "amd"
+      };
+      // await bundle.generate(outputOptions);
+      await bundle.write(outputOptions);
+    })
+  );
 
   const karmaConfig = { port: 9876 };
   myKarmaConfig({

--- a/run_tests.js
+++ b/run_tests.js
@@ -45,7 +45,8 @@ async function init() {
     ].map(async input => {
       const pathName = path.dirname(input);
       let rollupConfig = {
-        input
+        input,
+        strictDeprecations: true
       };
       const rollupConfigPath = "./" + path.join(pathName, "rollup.config.js");
       const configPath = "./" + path.join(pathName, "config.json");

--- a/tests/fixtures/assets-in-worker/rollup.config.js
+++ b/tests/fixtures/assets-in-worker/rollup.config.js
@@ -13,8 +13,12 @@ module.exports = (config, omt) => {
         if (id !== MARKER) {
           return;
         }
-        const assetReferenceId = this.emitAsset("my-asset.bin", "assetcontent");
-        return `export default import.meta.ROLLUP_ASSET_URL_${assetReferenceId}`;
+        const referenceId = this.emitFile({
+          type: "asset",
+          name: "my-asset.bin",
+          source: "assetcontent"
+        });
+        return `export default import.meta.ROLLUP_FILE_URL_${referenceId}`;
       }
     }
   ];


### PR DESCRIPTION
As I see you already started, this PR will just update one deprecated function you may have missed, add the `strictDeprecations` flag to your test setup to throw when deprecated functionality is used, and update Rollup to the 2.0.0-0 pre-release.

Also, I slightly streamlined the tests to remove an unneeded "generateBundle" and make Karma actually wait until bundling is done.

The reason I am doing this is that I actually quite like the plugin and also need it for a workshop I will be giving. For that, I will also need some more functionality where I am not 100% sure if you are interested in providing:

- Automatically remove `{type: "module"}` from `new Worker` calls. This will allow for isomorphic setups where you are not bundling in development but just use a bowser that supports module workers. But admittedly, keeping it may not actually cause issues...
- Refactor the loader code to just use Promises instead of async-await. I know async-await is supported by 91% of used browsers by now. But it is particularly hard to transpile and polyfill. This change will push compatibility to 94% but also make it easy to transpile to even lower compatibility targets while simply needing a Promise polyfill.