### PR TITLE
Emit module-relative `new URL` expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ This will become a hard error in the future.`, matchIndex);
     },
 
     resolveFileUrl(chunk) {
-      return `"./${chunk.fileName}"`;
+      return JSON.stringify(chunk.relativePath);
     },
 
     renderChunk(code, chunk, outputOptions) {

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ module.exports = function(opts = {}) {
           workerFile,
           optionsStrWithComma = "",
           optionsStr = "",
-          partAfterArgs,
+          partAfterArgs
         ) => {
           // We need to get this before the `await`, otherwise `lastIndex`
           // will be already overridden.
@@ -135,16 +135,22 @@ module.exports = function(opts = {}) {
               const fullReplacement = `new Worker(new URL(${directWorkerFile}, import.meta.url)${optionsStrWithComma})`;
 
               if (!longWarningAlreadyShown) {
-              this.warn(`rollup-plugin-off-main-thread:
+                this.warn(
+                  `rollup-plugin-off-main-thread:
 \`${fullMatch}\` suggests that the Worker should be relative to the document, not the script.
 In the bundler, we don't know what the final document's URL will be, and instead assume it's a URL relative to the current module.
 This might lead to incorrect behaviour during runtime.
 If you did mean to use a URL relative to the current module, please change your code to the following form:
 \`${fullReplacement}\`
-This will become a hard error in the future.`, matchIndex);
-                  longWarningAlreadyShown = true;
+This will become a hard error in the future.`,
+                  matchIndex
+                );
+                longWarningAlreadyShown = true;
               } else {
-                this.warn(`rollup-plugin-off-main-thread: Treating \`${fullMatch}\` as \`${fullReplacement}\``, matchIndex);
+                this.warn(
+                  `rollup-plugin-off-main-thread: Treating \`${fullMatch}\` as \`${fullReplacement}\``,
+                  matchIndex
+                );
               }
               workerFile = directWorkerFile;
             }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
     autoWatch: true,
     singleRun: true,
     concurrency: 1,
-    browsers: ["Chrome"],
+    browsers: ["Chrome", "Firefox", "Safari"],
     customLaunchers: {
       DockerChrome: {
         base: "ChromeHeadless",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
     autoWatch: true,
     singleRun: true,
     concurrency: 1,
-    browsers: ["Chrome", "Firefox", "Safari"],
+    browsers: ["Chrome"],
     customLaunchers: {
       DockerChrome: {
         base: "ChromeHeadless",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "chai": "4.2.0",
+    "chalk": "^2.4.2",
     "karma": "4.2.0",
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "3.0.0",

--- a/run_tests.js
+++ b/run_tests.js
@@ -57,21 +57,23 @@ async function init() {
         strictDeprecations: true,
         // Copied / adapted from default `onwarn` in Rollup CLI.
         onwarn: warning => {
-          console.warn( `⚠️   ${chalk.bold( warning.message )}` );
+          console.warn(`⚠️   ${chalk.bold(warning.message)}`);
 
-          if ( warning.url ) {
-            console.warn( chalk.cyan( warning.url ) );
+          if (warning.url) {
+            console.warn(chalk.cyan(warning.url));
           }
 
-          if ( warning.loc ) {
-            console.warn( `${ warning.loc.file } (${warning.loc.line}:${warning.loc.column})` );
+          if (warning.loc) {
+            console.warn(
+              `${warning.loc.file} (${warning.loc.line}:${warning.loc.column})`
+            );
           }
 
-          if ( warning.frame ) {
-            console.warn( chalk.dim( warning.frame ) );
+          if (warning.frame) {
+            console.warn(chalk.dim(warning.frame));
           }
 
-          console.warn( '' );
+          console.warn("");
         }
       };
       const rollupConfigPath = "./" + path.join(pathName, "rollup.config.js");

--- a/run_tests.js
+++ b/run_tests.js
@@ -15,6 +15,7 @@ const rollup = require("rollup");
 const path = require("path");
 const omt = require(".");
 const fs = require("fs");
+const chalk = require("chalk");
 
 const karma = require("karma");
 const myKarmaConfig = require("./karma.conf.js");
@@ -53,7 +54,25 @@ async function init() {
       };
       let rollupConfig = {
         input,
-        strictDeprecations: true
+        strictDeprecations: true,
+        // Copied / adapted from default `onwarn` in Rollup CLI.
+        onwarn: warning => {
+          console.warn( `⚠️   ${chalk.bold( warning.message )}` );
+
+          if ( warning.url ) {
+            console.warn( chalk.cyan( warning.url ) );
+          }
+
+          if ( warning.loc ) {
+            console.warn( `${ warning.loc.file } (${warning.loc.line}:${warning.loc.column})` );
+          }
+
+          if ( warning.frame ) {
+            console.warn( chalk.dim( warning.frame ) );
+          }
+
+          console.warn( '' );
+        }
       };
       const rollupConfigPath = "./" + path.join(pathName, "rollup.config.js");
       const configPath = "./" + path.join(pathName, "config.json");

--- a/tests/fixtures/module-worker/build/runner.html
+++ b/tests/fixtures/module-worker/build/runner.html
@@ -12,4 +12,4 @@ limitations under the License.
 -->
 
 <!doctype html>
-<script src="entry.js"></script>
+<script src="entry.js" type="module"></script>


### PR DESCRIPTION
- Fixes the output of #32 to emit `new URL('./worker.js', import.meta.url)` instead of just './worker.js', so that URLs are still module-relative after transform.
 - Changes handling of `new Worker('./worker.js')` to also be treated as `new Worker(new URL('./worker.js'), import.meta.url)` with a loud warning that this is not always correct and suggestion to use an explicit form.
 - Adds locations to existing warnings.
 - Disallows using root-relative URLs like `new Worker('/worker.js')` - these already didn't work, but failed with a worse internal error.