### PR TITLE
Various AMD improvements

### DIFF
--- a/loader.ejs
+++ b/loader.ejs
@@ -13,75 +13,64 @@
 
 // If the loader is already loaded, just stop.
 if (!self.<%- amdFunctionName %>) {
-  const singleRequire = name => {
-    if (name !== 'require') {
-      name = name + '.js';
-    }
-    let promise = Promise.resolve();
-    if (!registry[name]) {
+  let registry = {};
+
+  // Used for `eval` and `importScripts` where we can't get script URL by other means.
+  // In both cases, it's safe to use a global var because those functions are synchronous.
+  let nextDefineUri;
+
+  const singleRequire = (uri, parentUri) => {
+    uri = new URL(uri + ".js", parentUri).href;
+    return registry[uri] || (
       <% if (useEval) { %>
-        promise = fetch(name)
+        fetch(uri)
           .then(resp => resp.text())
-          .then(code => eval(code));
+          .then(code => {
+            nextDefineUri = uri;
+            eval(code);
+          })
       <% } else { %>
-        promise = new Promise(async resolve => {
+        new Promise(resolve => {
           if ("document" in self) {
             const script = document.createElement("script");
-            script.src = name;
-            document.head.appendChild(script);
+            script.src = uri;
             script.onload = resolve;
+            document.head.appendChild(script);
           } else {
-            importScripts(name);
+            nextDefineUri = uri;
+            importScripts(uri);
             resolve();
           }
-        });
+        })
       <% } %>
-    }
-    return promise.then(() => {
-      if (!registry[name]) {
-        throw new Error(`Module ${name} didn’t register its module`);
-      }
-      return registry[name];
-    });
+      .then(() => {
+        let promise = registry[uri];
+        if (!promise) {
+          throw new Error(`Module ${uri} didn’t register its module`);
+        }
+        return promise;
+      })
+    );
   };
 
-  const require = (names, resolve) => {
-    Promise.all(names.map(singleRequire))
-      .then(modules => resolve(modules.length === 1 ? modules[0] : modules));
-  };
-  
-  const registry = {
-    require: Promise.resolve(require)
-  };
-
-  self.<%- amdFunctionName %> = (moduleName, depsNames, factory) => {
-    if (registry[moduleName]) {
+  self.<%- amdFunctionName %> = (depsNames, factory) => {
+    const uri = nextDefineUri || ("document" in self ? document.currentScript.src : location.href);
+    if (registry[uri]) {
       // Module is already loading or loaded.
       return;
     }
-    registry[moduleName] = Promise.resolve().then(() => {
-      let exports = {};
-      const module = {
-        uri: moduleName.slice(2)
-      };
-      return Promise.all(
-        depsNames.map(depName => {
-          switch(depName) {
-            case "exports":
-              return exports;
-            case "module":
-              return module;
-            default:
-              return singleRequire(depName);
-          }
-        })
-      ).then(deps => {
-        const facValue = factory(...deps);
-        if(!exports.default) {
-          exports.default = facValue;
-        }
-        return exports;
-      });
+    let exports = {};
+    const require = depUri => singleRequire(depUri, uri);
+    const specialDeps = {
+      module: { uri },
+      exports,
+      require
+    };
+    registry[uri] = Promise.all(depsNames.map(
+      depName => specialDeps[depName] || require(depName)
+    )).then(deps => {
+      factory(...deps);
+      return exports;
     });
   };
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "karma-safaritechpreview-launcher": "2.0.2",
     "mocha": "6.1.4",
     "prettier": "1.18.2",
-    "rollup": "2.0.0-0"
+    "rollup": "2.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - Use a new `renderDynamicImport` hook from Rollup 2.2.0+ to produce smaller dynamic import expressions.
     - Before: `new Promise((resolve, reject) => require(['some-id'], resolve, reject).then(...)`
     - After:  `require('some-id').then(...)`
 - Keep `define(...)` calls anonymous in the source for compatibility with regular AMD loaders.
 - Store fully resolved URLs for each module in the built-in loader. This not only helps anonymous `define` above, but also makes output more robust in presence of multiple bundles on the page or differently nested directories.
 
   In particular, this makes `publicPath` option from https://github.com/surma/rollup-plugin-loadz0r/issues/9 and #6 unnecessary as all modules are now loaded relatively to the current one.
 - Since we're storing full URLs, use custom `resolveImportMeta` hook to produce smaller output for `import.meta.url`.
     - Before: `new URL(module.uri, document.baseURI).href`
     - After:  `module.uri`
 - Remove custom handling for `exports.default` - looks like Rollup already outputs the right thing on the imports side.
 - Few more simplifications for code size.