### PR TITLE
Use fix version of vulnerable dependent package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@surma/rollup-plugin-off-main-thread",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Use Rollup with workers and ES6 modules today.",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "url": "https://github.com/surma/rollup-plugin-off-main-thread"
   },
   "dependencies": {
-    "ejs": "^2.6.1",
+    "ejs": "^3.1.6",
     "magic-string": "^0.25.0",
     "tippex": "^3.0.0"
   }


### PR DESCRIPTION
There was a security vulnerability published for ejs package https://snyk.io/vuln/SNYK-JS-EJS-1049328
Bumping dependent package version to use its fix version