### PR TITLE
Fix Module Workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "ejs": "^2.6.1",
+    "json5": "^2.2.0",
     "magic-string": "^0.25.0",
     "tippex": "^3.0.0"
   }

--- a/tests/fixtures/module-worker/a.js
+++ b/tests/fixtures/module-worker/a.js
@@ -11,7 +11,10 @@
  * limitations under the License.
  */
 
-export default async function() {
-  const { default: f } = await import("./b.js");
+export default async function(f) {
   self.postMessage(f());
+}
+
+export function someValue() {
+  return self.String("a");
 }

--- a/tests/fixtures/module-worker/b.js
+++ b/tests/fixtures/module-worker/b.js
@@ -11,6 +11,10 @@
  * limitations under the License.
  */
 
+// Import for side-effects (of which there are none)
+// to make sure that a.js gets its own chunk.
+import {someValue} from "./a.js";
+
 export default function() {
-  return "a";
+  return someValue();
 }

--- a/tests/fixtures/module-worker/worker.js
+++ b/tests/fixtures/module-worker/worker.js
@@ -12,6 +12,6 @@
  */
 
 import a from "./a.js";
-
-a();
-import("./b.js");
+import("./b.js").then(({default: f}) => {
+  a(f);
+})


### PR DESCRIPTION
Currently, `{type: "module"}` _always_ gets removed. 

**This PR doesn’t fix that yet.**

But now the test properly detects that this is in fact not working.

Let’s work in this PR to fix that.