### PR TITLE
Add support for plain filenames in `new URL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,27 @@ export default {
 
 ### Auto bundling
 
-In your project's code:
+In your project's code use a module-relative path via `new URL` to include a Worker:
+
+```js
+const worker = new Worker(new URL("worker.js", import.meta.url), {
+  type: "module"
+});
+```
+
+This will just work.
+
+If required, the plugin also supports plain literal paths:
 
 ```js
 const worker = new Worker("./worker.js", { type: "module" });
 ```
 
-This will just work.
+However, those are less portable: in Rollup they would result in module-relative
+path, but if used directly in the browser, they'll be relative to the document
+URL instead.
 
-If required, the plugin also supports explicitly module-relative paths:
-
-```js
-const worker = new Worker(new URL("./worker.js", import.meta.url), {
-  type: "module"
-});
-```
+Hence, they're deprecated and `new URL` pattern is encouraged instead for portability.
 
 ### Importing workers as URLs
 

--- a/tests/fixtures/url-import-meta-worker/entry.js
+++ b/tests/fixtures/url-import-meta-worker/entry.js
@@ -12,7 +12,7 @@
  */
 
 // The type module should get removed for AMD format!
-const w = new Worker(new URL("./worker.js", import.meta.url), {
+const w = new Worker(new URL("worker.js", import.meta.url), {
   type: "module"
 });
 w.addEventListener("message", ev => {


### PR DESCRIPTION
Those are supported by other implementations, but we're dealing with module IDs in Rollup, so need to sprinkle a bit more magic for compatibility.

While at it, discourage `new Worker('./plain-url')` pattern in docs.