### PR TITLE
Make 'omt:' URLs have relative emitted paths in sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
 "use strict";
 
 const { readFileSync } = require("fs");
-const { join } = require("path");
+const { join, resolve, relative, isAbsolute } = require("path");
 const ejs = require("ejs");
 const MagicString = require("magic-string");
 const json5 = require("json5");
@@ -58,6 +58,12 @@ const workerRegexpForOutput = /new\s+Worker\(new\s+URL\((?:'.*?'|".*?"),\s*modul
 
 let longWarningAlreadyShown = false;
 
+// Logic from rollup src/utils/relativeId.ts
+function relativeId(id) {
+  if (!isAbsolute(id)) return id;
+  return relative(resolve(), id);
+}
+
 module.exports = function(opts = {}) {
   opts = Object.assign({}, defaultOpts, opts);
 
@@ -78,19 +84,29 @@ module.exports = function(opts = {}) {
       if (!id.startsWith(urlLoaderPrefix)) return;
 
       const path = id.slice(urlLoaderPrefix.length);
-      const resolved = await this.resolve(path, importer);
+      const resolved = await this.resolve(path, importer, {skipSelf: true});
       if (!resolved)
         throw Error(`Cannot find module '${path}' from '${importer}'`);
-      const newId = resolved.id;
-
-      return urlLoaderPrefix + newId;
+      const resolvedPathRel = relativeId(resolved.id);
+      return {
+        ...resolved,
+        id: urlLoaderPrefix + resolvedPathRel,
+        meta: {
+          ...resolved.meta,
+          omt: { realId: resolved.id, importer },
+        },
+      };
     },
 
     load(id) {
-      if (!id.startsWith(urlLoaderPrefix)) return;
+      const {meta} = this.getModuleInfo(id);
+      if (!meta.omt) return;
 
-      const realId = id.slice(urlLoaderPrefix.length);
-      const chunkRef = this.emitFile({ id: realId, type: "chunk" });
+      const chunkRef = this.emitFile({
+        type: "chunk",
+        id: meta.omt.realId,
+        importer: meta.omt.importer,
+      });
       return `export default import.meta.ROLLUP_FILE_URL_${chunkRef};`;
     },
 


### PR DESCRIPTION
Currently sourcemaps with `omt:` URLs contain the absolute path of the resolved file on the system running rollup.
Which potentially leaks sensitive information (e.g. the developer's local username).

This makes them relative to the rollup config and consistent with how other paths appear.