### PR TITLE
Update ejs version from `3.1.6` to `3.1.7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/surma/rollup-plugin-off-main-thread"
   },
   "dependencies": {
-    "ejs": "^3.1.6",
+    "ejs": "^3.1.7",
     "json5": "^2.2.0",
     "magic-string": "^0.25.0",
     "string.prototype.matchall": "^4.0.6"


### PR DESCRIPTION
It seems that there is a high severity issue due to `ejs 3.1.6` dependency.

See https://github.com/mde/ejs/issues/668