### PR TITLE
Update ejs to version 3.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/surma/rollup-plugin-off-main-thread"
   },
   "dependencies": {
-    "ejs": "^3.1.6",
+    "ejs": "^3.1.8",
     "json5": "^2.2.0",
     "magic-string": "^0.25.0",
     "string.prototype.matchall": "^4.0.6"


### PR DESCRIPTION
Description: Updated ejs to version `3.1.8` to resolve a critical github issue

- This resolves issues the Github issue mentioned [here](https://github.com/advisories/GHSA-phwq-j96m-2c2q)
- And also the issue mentioned [here](https://github.com/surma/rollup-plugin-off-main-thread/issues/52)
