### PR TITLE
Upgrade magic-string to avoid warnings in other projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "ejs": "^3.1.6",
     "json5": "^2.2.0",
-    "magic-string": "^0.25.0",
+    "magic-string": "^0.30.0",
     "string.prototype.matchall": "^4.0.6"
   }
 }


### PR DESCRIPTION
As the version is 0.x, npm refuses to automatically use a newer minor version. All users, including all workbox users, see
'npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead'