### PR TITLE
Remove string-prototype-matchall

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,6 @@ const { join } = require("path");
 const ejs = require("ejs");
 const MagicString = require("magic-string");
 const json5 = require("json5");
-// See https://github.com/surma/rollup-plugin-off-main-thread/issues/49
-const matchAll = require("string.prototype.matchall");
 
 const defaultOpts = {
   // A string containing the EJS template for the amd loader. If `undefined`,
@@ -101,7 +99,7 @@ module.exports = function(opts = {}) {
 
       const replacementPromises = [];
 
-      for (const match of matchAll(code, workerRegexpForTransform)) {
+      for (const match of code.matchAll(workerRegexpForTransform)) {
         let [
           fullMatch,
           partBeforeArgs,
@@ -263,7 +261,7 @@ This will become a hard error in the future.`,
       }
       const ms = new MagicString(code);
 
-      for (const match of matchAll(code, workerRegexpForOutput)) {
+      for (const match of code.matchAll(workerRegexpForOutput)) {
         let [fullMatch, optionsWithCommaStr, optionsStr] = match;
         let options;
         try {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "ejs": "^3.1.6",
     "json5": "^2.2.0",
-    "magic-string": "^0.25.0",
-    "string.prototype.matchall": "^4.0.6"
+    "magic-string": "^0.25.0"
   }
 }


### PR DESCRIPTION
Removes `string-prototype-matchall`. Support for `String.prototype.matchAll` landed in Node.js v12, and Node.js v16 reached EOL in September 2023, so I agree with the poster of #58 that the need for this shim is now gone. While reviewing my own package dependencies, this was a big source. Thank you!


- Fixes #58
- Reverts #50